### PR TITLE
Added missing dep for Cake.ExtendedNuGet

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,4 +1,5 @@
 #addin "Cake.ExtendedNuGet"
+#addin "nuget:?package=NuGet.Protocol&version=5.0.2.0"
 #addin "nuget:?package=NuGet.Core&version=2.14.0"
 #tool "nuget:?package=JetBrains.dotCover.CommandLineTools"
 


### PR DESCRIPTION
Cake.ExtendedNuGet is dependent on Nuget.Protocol, but not according to the nugetfile