### PR TITLE
[WIP] [BUGFIX] re #19075 - Hubspot - Disconnect company does not syncronize…

### DIFF
--- a/src/HubSpot/Companies/Company.cs
+++ b/src/HubSpot/Companies/Company.cs
@@ -38,7 +38,7 @@ namespace HubSpot.Companies
 
         [CustomProperty("country")]
         public string Country { get; set; }
-
-        IReadOnlyDictionary<string, object> IHubSpotEntity.Properties { get; set; } = new Dictionary<string, object>();
+        
+        public Dictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
     }
 }

--- a/src/HubSpot/Contacts/Contact.cs
+++ b/src/HubSpot/Contacts/Contact.cs
@@ -38,6 +38,6 @@ namespace HubSpot.Contacts
         [CustomProperty("associatedcompanyid")]
         public long AssociatedCompanyId { get; set; }
 
-        IReadOnlyDictionary<string, object> IHubSpotEntity.Properties { get; set; } = new Dictionary<string, object>();
+        Dictionary<string, object> IHubSpotEntity.Properties { get; set; } = new Dictionary<string, object>();
     }
 }

--- a/src/HubSpot/Converters/IntTypeConverter.cs
+++ b/src/HubSpot/Converters/IntTypeConverter.cs
@@ -33,6 +33,12 @@
                 return true;
             }
 
+            if (int.TryParse(value.ToString(), out int numberResult))
+            {
+                result = numberResult.ToString("D");
+                return true;
+            }
+
             result = null;
             return false;
         }

--- a/src/HubSpot/Deals/Deal.cs
+++ b/src/HubSpot/Deals/Deal.cs
@@ -38,7 +38,7 @@ namespace HubSpot.Deals
 
         public IReadOnlyList<long> AssociatedDealIds { get; set; } = Array.Empty<long>();
 
-        IReadOnlyDictionary<string, object> IHubSpotEntity.Properties { get; set; } = new Dictionary<string, object>();
+        Dictionary<string, object> IHubSpotEntity.Properties { get; set; } = new Dictionary<string, object>();
 
         IReadOnlyDictionary<string, IReadOnlyList<long>> IHubSpotDealEntity.Associations { get; set; } = new Dictionary<string, IReadOnlyList<long>>();
     }

--- a/src/HubSpot/HubSpotEntity.cs
+++ b/src/HubSpot/HubSpotEntity.cs
@@ -4,7 +4,7 @@ namespace HubSpot
 {
     public interface IHubSpotEntity
     {
-        IReadOnlyDictionary<string, object> Properties { get; set; }
+        Dictionary<string, object> Properties { get; set; }
     }
 
     public struct PropertyData


### PR DESCRIPTION
… hubspot data

update Properties dictionary to not readonly
add tryParse to intConverter

This bug is about disconnect Company not setting customer card to null in hubspot. The issue was that Properties were not included in WCF contract and to be able to do that I had to make IReadOnlyDictionary to Dictionary. Property value had to be set as string in contract so in order to convert that back I had to add a tryParse to the IntTypeConverter.