### PR TITLE
Properties reset

### DIFF
--- a/src/HubSpot/Companies/HubSpotCompanyConnector.cs
+++ b/src/HubSpot/Companies/HubSpotCompanyConnector.cs
@@ -50,7 +50,7 @@ namespace HubSpot.Companies
             var customProperties = (from property in _typeManager.GetPropertyData(company)
                                       select new ValuedPropertyV2(property.PropertyName, property.Value?.ToString())).ToArray();
 
-            if (customProperties.All(cp => string.IsNullOrEmpty(cp.Value)))
+            if (customProperties.All(cp => string.IsNullOrEmpty(cp.Value)) && IsNew())
             {
                 return company;
             }

--- a/src/HubSpot/Companies/HubSpotCompanyConnector.cs
+++ b/src/HubSpot/Companies/HubSpotCompanyConnector.cs
@@ -48,7 +48,8 @@ namespace HubSpot.Companies
             }
 
             var customProperties = (from property in _typeManager.GetPropertyData(company)
-                                      select new ValuedPropertyV2(property.PropertyName, property.Value?.ToString())).ToArray();
+                                      select new ValuedPropertyV2(property.PropertyName, property.Value?.ToString()))
+                                      .ToArray();
 
             if (customProperties.All(cp => string.IsNullOrEmpty(cp.Value)) && IsNew())
             {

--- a/src/HubSpot/Companies/HubSpotCompanyConnector.cs
+++ b/src/HubSpot/Companies/HubSpotCompanyConnector.cs
@@ -47,26 +47,24 @@ namespace HubSpot.Companies
                 throw new ArgumentNullException(nameof(company));
             }
 
-            var modifiedProperties = (from property in _typeManager.GetModifiedProperties(company)
-                                      select new ValuedPropertyV2(property.name, property.value)).ToArray();
+            var customProperties = (from property in _typeManager.GetPropertyData(company)
+                                      select new ValuedPropertyV2(property.PropertyName, property.Value?.ToString())).ToArray();
 
-            if (modifiedProperties.Any())
+            if (customProperties.All(cp => string.IsNullOrEmpty(cp.Value)))
             {
-                if (IsNew())
-                {
-                    var createdCompany = await _client.Companies.CreateAsync(modifiedProperties).ConfigureAwait(false);
-                    var newCompany = await _client.Companies.GetByIdAsync(createdCompany.Id).ConfigureAwait(false);
-                    return _typeManager.ConvertTo<TCompany>(newCompany);
-                }
-                else
-                {
-                    await _client.Companies.UpdateAsync(company.Id, modifiedProperties).ConfigureAwait(false);
-                    var modifiedCompany = await _client.Companies.GetByIdAsync(company.Id).ConfigureAwait(false);
-                    return _typeManager.ConvertTo<TCompany>(modifiedCompany);
-                }
+                return company;
             }
 
-            return company;
+            if (IsNew())
+            {
+                var createdCompany = await _client.Companies.CreateAsync(customProperties).ConfigureAwait(false);
+                var newCompany = await _client.Companies.GetByIdAsync(createdCompany.Id).ConfigureAwait(false);
+                return _typeManager.ConvertTo<TCompany>(newCompany);
+            }
+            
+            await _client.Companies.UpdateAsync(company.Id, customProperties).ConfigureAwait(false);
+            var modifiedCompany = await _client.Companies.GetByIdAsync(company.Id).ConfigureAwait(false);
+            return _typeManager.ConvertTo<TCompany>(modifiedCompany);
 
             bool IsNew()
             {

--- a/src/HubSpot/Contacts/HubSpotContactConnector.cs
+++ b/src/HubSpot/Contacts/HubSpotContactConnector.cs
@@ -53,7 +53,7 @@ namespace HubSpot.Contacts
             var customProperties = (from property in _typeManager.GetPropertyData(contact)
                                       select new ValuedProperty(property.PropertyName, property.Value?.ToString())).ToArray();
 
-            if (customProperties.All(cp => string.IsNullOrEmpty(cp.Value)))
+            if (customProperties.All(cp => string.IsNullOrEmpty(cp.Value)) && IsNewContact())
             {
                 return contact;
             }

--- a/src/HubSpot/Contacts/HubSpotContactConnector.cs
+++ b/src/HubSpot/Contacts/HubSpotContactConnector.cs
@@ -51,7 +51,8 @@ namespace HubSpot.Contacts
             }
 
             var customProperties = (from property in _typeManager.GetPropertyData(contact)
-                                      select new ValuedProperty(property.PropertyName, property.Value?.ToString())).ToArray();
+                                      select new ValuedProperty(property.PropertyName, property.Value?.ToString()))
+                                      .ToArray();
 
             if (customProperties.All(cp => string.IsNullOrEmpty(cp.Value)) && IsNewContact())
             {

--- a/src/HubSpot/Contacts/HubSpotContactConnector.cs
+++ b/src/HubSpot/Contacts/HubSpotContactConnector.cs
@@ -50,25 +50,23 @@ namespace HubSpot.Contacts
                 throw new ArgumentNullException(nameof(contact));
             }
 
-            var modifiedProperties = (from property in _typeManager.GetModifiedProperties(contact)
-                                      select new ValuedProperty(property.name, property.value)).ToArray();
+            var customProperties = (from property in _typeManager.GetPropertyData(contact)
+                                      select new ValuedProperty(property.PropertyName, property.Value?.ToString())).ToArray();
 
-            if (modifiedProperties.Any())
+            if (customProperties.All(cp => string.IsNullOrEmpty(cp.Value)))
             {
-                if (IsNewContact())
-                {
-                    var newContact = await _client.Contacts.CreateAsync(modifiedProperties);
-                    return _typeManager.ConvertTo<TContact>(newContact);
-                }
-                else
-                {
-                    await _client.Contacts.UpdateByIdAsync(contact.Id, modifiedProperties);
-                    var newContact = await GetAsync<TContact>(SelectContact.ById(contact.Id));
-                    return newContact;
-                }
+                return contact;
             }
 
-            return contact;
+            if (IsNewContact())
+            {
+                var newContact = await _client.Contacts.CreateAsync(customProperties);
+                return _typeManager.ConvertTo<TContact>(newContact);
+            }
+
+            await _client.Contacts.UpdateByIdAsync(contact.Id, customProperties);
+            var modifiedContact = await GetAsync<TContact>(SelectContact.ById(contact.Id));
+            return modifiedContact;
 
             bool IsNewContact()
             {

--- a/src/HubSpot/Deals/HubSpotDealConnector.cs
+++ b/src/HubSpot/Deals/HubSpotDealConnector.cs
@@ -47,7 +47,8 @@ namespace HubSpot.Deals
             }
 
             var customProperties = (from property in _typeManager.GetPropertyData(deal)
-                                      select new ValuedPropertyV2(property.PropertyName, property.Value?.ToString())).ToArray();
+                                      select new ValuedPropertyV2(property.PropertyName, property.Value?.ToString()))
+                                      .ToArray();
 
             var hasProperties = !customProperties.All(cp => string.IsNullOrEmpty(cp.Value));
 

--- a/src/HubSpot/Internal/ITypeManager.cs
+++ b/src/HubSpot/Internal/ITypeManager.cs
@@ -13,7 +13,7 @@ namespace HubSpot.Internal
         IReadOnlyList<CustomPropertyInfo> GetCustomProperties<T>(Func<CustomPropertyAttribute, bool> filter)
             where T : class, TEntity, new();
 
-        IReadOnlyList<(string name, string value)> GetModifiedProperties<T>(T item)
+        IReadOnlyList<PropertyData> GetPropertyData<T>(T item)
             where T : class, TEntity, new();
     }
 

--- a/tests/Tests.HubSpot/Contacts/HubSpotContactConnectorTests.cs
+++ b/tests/Tests.HubSpot/Contacts/HubSpotContactConnectorTests.cs
@@ -124,14 +124,14 @@ namespace Tests.Contacts
         }
 
         [Test, CustomAutoData]
-        public async Task SaveAsync_persists_a_new_contact(TestContact contact, (string, string)[] properties)
+        public async Task SaveAsync_persists_a_new_contact(TestContact contact, PropertyData[] properties)
         {
             contact.Id = 0;
             contact.Created = default;
 
             var toCreate = CreateFromContact(contact);
 
-            mockTypeManager.Setup(p => p.GetModifiedProperties(It.IsAny<TestContact>())).Returns(properties);
+            mockTypeManager.Setup(p => p.GetPropertyData(It.IsAny<TestContact>())).Returns(properties);
 
             mockContactClient.Setup(p => p.CreateAsync(It.IsAny<IReadOnlyList<ValuedProperty>>())).ReturnsAsync(toCreate);
 

--- a/tests/Tests.Integrations/Contacts/HubSpotContactConnectorTests.cs
+++ b/tests/Tests.Integrations/Contacts/HubSpotContactConnectorTests.cs
@@ -279,22 +279,6 @@ namespace Tests.Contacts
         }
 
         [Test, ContactAutoData]
-        public async Task Unmodified_contact_should_not_be_persisted(TestContact contact)
-        {
-            SetPropertyDictionary(contact);
-
-            var sut = CreateSystemUnderTest();
-
-            var newContact = await sut.SaveAsync(contact);
-
-            mockClient.Verify(p => p.CreateAsync(It.IsAny<IReadOnlyList<ValuedProperty>>()), Times.Never);
-
-            mockClient.Verify(p => p.UpdateByIdAsync(It.IsAny<long>(), It.IsAny<IReadOnlyList<ValuedProperty>>()), Times.Never);
-
-            Assert.That(newContact, Is.SameAs(contact));
-        }
-
-        [Test, ContactAutoData]
         public async Task Reference_property_reset_to_default_value_should_be_persisted(TestContact contact)
         {
             SetPropertyDictionary(contact);
@@ -309,7 +293,7 @@ namespace Tests.Contacts
 
             var newContact = await sut.SaveAsync(contact);
 
-            mockClient.Verify(p => p.UpdateByIdAsync(contact.Id, It.Is<IReadOnlyList<ValuedProperty>>(c => c.Single().Property == "customProperty")), Times.Once);
+            mockClient.Verify(p => p.UpdateByIdAsync(contact.Id, It.IsAny<IReadOnlyList<ValuedProperty>>()), Times.Once);
 
             Assert.That(newContact.CustomProperty, Is.Null);
         }
@@ -329,7 +313,7 @@ namespace Tests.Contacts
 
             var newContact = await sut.SaveAsync(contact);
 
-            mockClient.Verify(p => p.UpdateByIdAsync(contact.Id, It.Is<IReadOnlyList<ValuedProperty>>(c => c.Single().Property == "associatedcompanyid")), Times.Once);
+            mockClient.Verify(p => p.UpdateByIdAsync(contact.Id, It.IsAny<IReadOnlyList<ValuedProperty>>()), Times.Once);
 
             Assert.That(newContact.AssociatedCompanyId, Is.EqualTo(0));
         }


### PR DESCRIPTION
This PR adds the ability to reset properties of Companies, Deals and Contacts back to null. 

The problem is that we have previously tried to check for modified properties on the objects. However, the result of the check is all properties that have a value set to something other than null, and not a true diff of what has actually changed. 
Why we have not seen any issues with this previously is that the hubspot API seem to be smart enough to only update the properties that have actually been modified on the object. 

This PR will therefor remove our check for modified properties as it is not working and post all the properties of the object to hubspot. Their API is able to handle the diff instead of trying to do this in the SDK. 