### PR TITLE
[BUGFIX] re #19075 - Hubspot - Disconnect company does not syncronize…

### DIFF
--- a/src/HubSpot/Deals/Deal.cs
+++ b/src/HubSpot/Deals/Deal.cs
@@ -29,7 +29,7 @@ namespace HubSpot.Deals
         [CustomProperty("createdate")]
         public DateTimeOffset Created { get; set; }
 
-        [CustomProperty("num_associated_contacts")]
+        [CustomProperty("num_associated_contacts", IsReadOnly = true)]
         public long NumberOfAssociatedContacts { get; set; }
 
         public IReadOnlyList<long> AssociatedCompanyIds { get; set; } = Array.Empty<long>();


### PR DESCRIPTION
… hubspot data

add IsReadonly to property NumberOfAssociatedContacts

Since we are not allowed to update this property in hubspot we need to mark it as IsReadonly to be able to exclude it from properties that can be modified