### PR TITLE
BUGFIX re #19714 - Hubspot - Deal amount

### DIFF
--- a/src/HubSpot/Converters/DecimalTypeConverter.cs
+++ b/src/HubSpot/Converters/DecimalTypeConverter.cs
@@ -1,4 +1,6 @@
-﻿namespace HubSpot.Converters {
+﻿using System.Globalization;
+
+namespace HubSpot.Converters {
     public class DecimalTypeConverter : ITypeConverter
     {
         public bool TryConvertTo(string value, out object result)
@@ -29,7 +31,7 @@
 
             if (value is decimal num)
             {
-                result = num.ToString("D");
+                result = num.ToString("G", CultureInfo.InvariantCulture);
                 return true;
             }
 

--- a/tests/Tests.HubSpot/Converters/DecimalConverterTests.cs
+++ b/tests/Tests.HubSpot/Converters/DecimalConverterTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Globalization;
+using HubSpot.Converters;
+using NUnit.Framework;
+
+namespace Tests.Converters
+{
+    [TestFixture]
+    public class DecimalTypeConverterTests
+    {
+        [Test, CustomAutoData]
+        public void TryConvertTo_returns_true_if_value_is_null(DecimalTypeConverter sut)
+        {
+            var canConvert = sut.TryConvertTo(null, out _);
+
+            Assert.IsTrue(canConvert);
+        }
+
+        [Test, CustomAutoData]
+        public void TryConvertTo_result_is_default_if_value_is_null(DecimalTypeConverter sut)
+        {
+            _ = sut.TryConvertTo(null, out object result);
+
+            Assert.That(result, Is.EqualTo(default));
+        }
+
+        
+        [Test, CustomAutoData]
+        public void TryConvertFrom_returns_true_if_value_is_null(DecimalTypeConverter sut)
+        {
+            var canConvert = sut.TryConvertFrom(null, out _);
+
+            Assert.IsTrue(canConvert);
+        }
+
+        [Test, CustomAutoData]
+        public void TryConvertFrom_result_is_null_if_value_is_null(DecimalTypeConverter sut)
+        {
+            
+            _ = sut.TryConvertFrom(null, out string result);
+
+            Assert.IsNull(result);
+        }
+
+        [Test, CustomAutoData]
+        public void TryConvertFrom_returns_false_if_value_is_not_decimal(DecimalTypeConverter sut, string value)
+        {
+            var canConvert = sut.TryConvertFrom(value, out _);
+
+            Assert.IsFalse(canConvert);
+        }
+
+        [Test, CustomAutoData]
+        public void TryConvertFrom_result_is_dotted_decimal_string(DecimalTypeConverter sut, decimal dec)
+        {
+            _ = sut.TryConvertFrom(dec, out string result);
+
+            Assert.AreEqual(result, dec.ToString("G", CultureInfo.InvariantCulture));
+        }
+
+        [Test, CustomAutoData]
+        public void TryConvertFrom_result_is_not_containing_comma(DecimalTypeConverter sut, decimal dec)
+        {
+            _ = sut.TryConvertFrom(dec, out string result);
+
+            Assert.IsFalse(result.Contains(","));
+        }
+    }
+}


### PR DESCRIPTION
Decimal converter could not convert a decimal to a string. Switched format expression and locked to invariant culture.