### PR TITLE
re #19767 - External orders - CRM bubble + hubspot sdk

### DIFF
--- a/src/HubSpot.Client/HttpHubSpotClient.Pipelines.cs
+++ b/src/HubSpot.Client/HttpHubSpotClient.Pipelines.cs
@@ -1,0 +1,26 @@
+﻿using HubSpot.Model.Pipelines;
+using Kralizek.Extensions.Http;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HubSpot
+{
+    public partial class HttpHubSpotClient : IHubSpotPipelineClient
+    {
+        async Task<Pipeline> IHubSpotPipelineClient.GetByGuidAsync(string guid)
+        {
+            try
+            {
+                var result = await _client.GetAsync<Pipeline>($"/deals/v1/pipelines/{guid}");
+                return result;
+            }
+            catch (HttpException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                throw new NotFoundException("Pipeline not found", ex);
+            }
+        }
+    }
+}

--- a/src/HubSpot.Client/HttpHubSpotClient.cs
+++ b/src/HubSpot.Client/HttpHubSpotClient.cs
@@ -8,6 +8,7 @@ using HubSpot.Model.CRM.Associations;
 using HubSpot.Model.Deals;
 using HubSpot.Model.Lists;
 using HubSpot.Model.Owners;
+using HubSpot.Model.Pipelines;
 using HubSpot.Utils;
 using Kralizek.Extensions.Http;
 using Microsoft.Extensions.Logging;
@@ -51,5 +52,7 @@ namespace HubSpot
         public IHubSpotOwnerClient Owners => this;
 
         public IHubSpotCrmClient Crm => this;
+
+        public IHubSpotPipelineClient Pipelines => this;
     }
 }

--- a/src/HubSpot.Client/HttpHubSpotClient.cs
+++ b/src/HubSpot.Client/HttpHubSpotClient.cs
@@ -54,5 +54,6 @@ namespace HubSpot
         public IHubSpotCrmClient Crm => this;
 
         public IHubSpotPipelineClient Pipelines => this;
+
     }
 }

--- a/src/HubSpot.Client/IHubSpotClient.cs
+++ b/src/HubSpot.Client/IHubSpotClient.cs
@@ -4,6 +4,7 @@ using HubSpot.Model.CRM.Associations;
 using HubSpot.Model.Deals;
 using HubSpot.Model.Lists;
 using HubSpot.Model.Owners;
+using HubSpot.Model.Pipelines;
 
 namespace HubSpot
 {
@@ -14,6 +15,8 @@ namespace HubSpot
         IHubSpotCompanyClient Companies { get; }
 
         IHubSpotDealClient Deals { get; }
+
+        IHubSpotPipelineClient Pipelines { get; }
 
         IHubSpotListClient Lists { get; }
 

--- a/src/HubSpot.Client/Model/Pipelines/IHubSpotPipelineClient.cs
+++ b/src/HubSpot.Client/Model/Pipelines/IHubSpotPipelineClient.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HubSpot.Model.Pipelines
+{
+    public interface IHubSpotPipelineClient
+    {
+        Task<Pipeline> GetByGuidAsync(string guid);
+    }
+}

--- a/src/HubSpot.Client/Model/Pipelines/Pipeline.cs
+++ b/src/HubSpot.Client/Model/Pipelines/Pipeline.cs
@@ -1,0 +1,46 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace HubSpot.Model.Pipelines
+{
+    public class Pipeline
+    {
+        [JsonProperty("active")]
+        public bool IsActive { get; set; }
+
+        [JsonProperty("displayOrder")]
+        public int DisplayOrder { get; set; }
+
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        [JsonProperty("pipelineid")]
+        public string Guid { get; set; }
+
+        [JsonProperty("stages")]
+        public IReadOnlyList<StageProperty> Stages { get; set; }
+    }
+
+    public class StageProperty
+    { 
+        [JsonProperty("active")]
+        public bool IsActive { get; set; }
+
+        [JsonProperty("closedWon")]
+        public bool ClosedWon { get; set; }
+
+        [JsonProperty("displayOrder")]
+        public int DisplayOrder { get; set; }
+
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        [JsonProperty("probability")]
+        public decimal Probability { get; set; }
+
+        [JsonProperty("stageId")]
+        public string StageID { get; set; }
+    }
+}

--- a/src/HubSpot/Deals/Deal.cs
+++ b/src/HubSpot/Deals/Deal.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using HubSpot.Model.Pipelines;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -31,6 +32,11 @@ namespace HubSpot.Deals
 
         [CustomProperty("num_associated_contacts", IsReadOnly = true)]
         public long NumberOfAssociatedContacts { get; set; }
+
+        [CustomProperty("pipeline")]
+        public string PipelineGuid { get; set; }
+
+        public Pipeline Pipeline { get; set; }
 
         public IReadOnlyList<long> AssociatedCompanyIds { get; set; } = Array.Empty<long>();
 

--- a/src/HubSpot/Deals/HubSpotDealConnector.cs
+++ b/src/HubSpot/Deals/HubSpotDealConnector.cs
@@ -30,6 +30,7 @@ namespace HubSpot.Deals
             {
                 var hubspotDeal = await selector.GetDeal(_client).ConfigureAwait(false);
                 var deal = _typeManager.ConvertTo<TDeal>(hubspotDeal);
+                deal.Pipeline = await _client.Pipelines.GetByGuidAsync(deal.PipelineGuid);
                 return deal;
             }
             catch (NotFoundException)

--- a/tests/Tests.HubSpot.Client/CustomAutoDataAttribute.cs
+++ b/tests/Tests.HubSpot.Client/CustomAutoDataAttribute.cs
@@ -50,6 +50,8 @@ namespace Tests
 
             fixture.Register((HttpHubSpotClient client) => client.Owners);
 
+            fixture.Register((HttpHubSpotClient client) => client.Pipelines);
+
             fixture.Register((HttpHubSpotClient client) => client.Contacts.Properties);
 
             fixture.Register((HttpHubSpotClient client) => client.Contacts.PropertyGroups);

--- a/tests/Tests.HubSpot.Client/Pipelines/HubSpotPipelineClientTests.cs
+++ b/tests/Tests.HubSpot.Client/Pipelines/HubSpotPipelineClientTests.cs
@@ -1,0 +1,101 @@
+﻿using AutoFixture;
+using AutoFixture.Idioms;
+using AutoFixture.NUnit3;
+using HubSpot;
+using HubSpot.Model.Pipelines;
+using Kralizek.Extensions.Http;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests.Pipelines
+{
+    [TestFixture]
+    public class HubSpotPipelineClientTests
+    {
+        [Test, CustomAutoData]
+        public void Constructor_is_guarded_against_null_parameters(GuardClauseAssertion guardClauseAssertion)
+        {
+            //Arrange
+
+            //Act
+
+            //Assert
+            guardClauseAssertion.Verify(typeof(HttpHubSpotClient).GetConstructors());
+        }
+
+        [Test, CustomAutoData]
+        public void GetByGuidAsync_throws_NotFoundException_if_request_returns_NotFound_status([Frozen] IHttpRestClient httpRestClient, IHubSpotPipelineClient sut, string guid)
+        {
+            //Arrange
+            Mock.Get(httpRestClient)
+                .Setup(p => p.SendAsync<Pipeline>(HttpMethod.Get, $"/deals/v1/pipelines/{guid}", null))
+                .Throws(new HttpException("Not Found", HttpStatusCode.NotFound));
+
+            //Act
+
+            //Assert
+            Assert.That(() => sut.GetByGuidAsync(guid), Throws.InstanceOf<NotFoundException>());
+        }
+
+        [Test, CustomAutoData]
+        public void GetByGuidAsync_invokes_http_client_get_method_once_with_guid([Frozen] IHttpRestClient httpRestClient, IHubSpotPipelineClient sut, string guid)
+        {
+            //Arrange
+
+            //Act
+            sut.GetByGuidAsync(guid);
+
+            //Assert
+            Mock.Get(httpRestClient).Verify(p => p.SendAsync<Pipeline>(HttpMethod.Get, $"/deals/v1/pipelines/{guid}", null), Times.Once);
+        }
+
+        [Test, CustomAutoData]
+        public async Task GetByGuidAsync_returns_null_if_guid_is_empty([Frozen] IHttpRestClient httpRestClient, IHubSpotPipelineClient sut)
+        {
+            //Arrange
+            Mock.Get(httpRestClient)
+                .Setup(p => p.SendAsync<Pipeline>(HttpMethod.Get, $"/deals/v1/pipelines/{string.Empty}", null)).Returns(Task.FromResult((Pipeline)null));
+
+            //Act
+            var result = await sut.GetByGuidAsync(string.Empty);
+
+            //Assert
+            Assert.That(result, Is.Null);
+        }
+
+        [Test, CustomAutoData]
+        public async Task GetByGuidAsync_returns_pipeline_retrieved_by_http_client_request([Frozen] IHttpRestClient httpRestClient,[Frozen] Pipeline pipeline, IHubSpotPipelineClient sut, string guid)
+        {
+            //Arrange
+            Mock.Get(httpRestClient)
+                .Setup(p => p.SendAsync<Pipeline>(HttpMethod.Get, $"/deals/v1/pipelines/{guid}", null)).Returns(Task.FromResult(pipeline));
+
+            //Act
+            var result = await sut.GetByGuidAsync(guid);
+
+            //Assert
+            Assert.That(result, Is.EqualTo(pipeline));
+        }
+
+        [Test, CustomAutoData]
+        public async Task GetByGuidAsync_returns_pipeline_with_valid_guid([Frozen] IHttpRestClient httpRestClient, IHubSpotPipelineClient sut, string guid, IFixture fixture)
+        {
+            //Arrange
+            var pipeline = fixture.Build<Pipeline>().With(x => x.Guid, guid).Create();
+            Mock.Get(httpRestClient)
+                .Setup(p => p.SendAsync<Pipeline>(HttpMethod.Get, $"/deals/v1/pipelines/{guid}", null)).Returns(Task.FromResult(pipeline));
+
+            //Act
+            var result = await sut.GetByGuidAsync(guid);
+
+            //Assert
+            Assert.That(result.Guid, Is.EqualTo(guid));
+        }
+    }
+}

--- a/tests/Tests.HubSpot.Client/Pipelines/HubSpotPipelineClientTests.cs
+++ b/tests/Tests.HubSpot.Client/Pipelines/HubSpotPipelineClientTests.cs
@@ -30,12 +30,13 @@ namespace Tests.Pipelines
         }
 
         [Test, CustomAutoData]
-        public void GetByGuidAsync_throws_NotFoundException_if_request_returns_NotFound_status([Frozen] IHttpRestClient httpRestClient, IHubSpotPipelineClient sut, string guid)
+        public void GetByGuidAsync_throws_NotFoundException_if_request_returns_NotFound_status([Frozen] IHttpRestClient httpRestClient, IHubSpotPipelineClient sut, string guid, IFixture fixture)
         {
             //Arrange
+            var httpException = fixture.Build<HttpException>().With(x => x.StatusCode, HttpStatusCode.NotFound).Create();
             Mock.Get(httpRestClient)
                 .Setup(p => p.SendAsync<Pipeline>(HttpMethod.Get, $"/deals/v1/pipelines/{guid}", null))
-                .Throws(new HttpException("Not Found", HttpStatusCode.NotFound));
+                .Throws(httpException);
 
             //Act
 
@@ -56,14 +57,14 @@ namespace Tests.Pipelines
         }
 
         [Test, CustomAutoData]
-        public async Task GetByGuidAsync_returns_null_if_guid_is_empty([Frozen] IHttpRestClient httpRestClient, IHubSpotPipelineClient sut)
+        public async Task GetByGuidAsync_returns_null_if_API_retrieves_null([Frozen] IHttpRestClient httpRestClient, IHubSpotPipelineClient sut, string guid)
         {
             //Arrange
             Mock.Get(httpRestClient)
-                .Setup(p => p.SendAsync<Pipeline>(HttpMethod.Get, $"/deals/v1/pipelines/{string.Empty}", null)).Returns(Task.FromResult((Pipeline)null));
+                .Setup(p => p.SendAsync<Pipeline>(HttpMethod.Get, $"/deals/v1/pipelines/{guid}", null)).Returns(Task.FromResult((Pipeline)null));
 
             //Act
-            var result = await sut.GetByGuidAsync(string.Empty);
+            var result = await sut.GetByGuidAsync(guid);
 
             //Assert
             Assert.That(result, Is.Null);

--- a/tests/Tests.HubSpot/Deals/HubSpotDealConnectorTests.cs
+++ b/tests/Tests.HubSpot/Deals/HubSpotDealConnectorTests.cs
@@ -97,10 +97,11 @@ namespace Tests.Deals
         }
 
         [Test, CustomAutoData]
-        public async Task GetAsync_returns_null_if_deal_retrieving_throws_NotFoundException([Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut)
+        public async Task GetAsync_returns_null_if_deal_retrieving_throws_NotFoundException([Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut, IFixture fixture)
         {
             //Arrange
-            Mock.Get(dealSelector).Setup(x => x.GetDeal(hubSpotClient)).Throws(new NotFoundException("Not Found", new Exception()));
+            var notFoundException = fixture.Create<NotFoundException>();
+            Mock.Get(dealSelector).Setup(x => x.GetDeal(hubSpotClient)).Throws(notFoundException);
 
             //Act
             var result = await sut.GetAsync<HubSpot.Deals.Deal>(dealSelector);
@@ -110,10 +111,11 @@ namespace Tests.Deals
         }
 
         [Test, CustomAutoData]
-        public async Task GetAsync_returns_null_if_pipeline_retrieving_throws_NotFoundeException([Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut, string guid)
+        public async Task GetAsync_returns_null_if_pipeline_retrieving_throws_NotFoundeException([Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut, string guid, IFixture fixture)
         {
             //Arrange
-            Mock.Get(hubSpotClient).Setup(x => x.Pipelines.GetByGuidAsync(It.IsAny<string>())).Throws(new NotFoundException("Not Found", new Exception()));
+            var notFoundException = fixture.Create<NotFoundException>();
+            Mock.Get(hubSpotClient).Setup(x => x.Pipelines.GetByGuidAsync(It.IsAny<string>())).Throws(notFoundException);
 
             //Act
             var result = await sut.GetAsync<HubSpot.Deals.Deal>(dealSelector);

--- a/tests/Tests.HubSpot/Deals/HubSpotDealConnectorTests.cs
+++ b/tests/Tests.HubSpot/Deals/HubSpotDealConnectorTests.cs
@@ -97,10 +97,9 @@ namespace Tests.Deals
         }
 
         [Test, CustomAutoData]
-        public async Task GetAsync_returns_null_if_deal_retrieving_throws_NotFoundException([Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut, IFixture fixture)
+        public async Task GetAsync_returns_null_if_deal_retrieving_throws_NotFoundException([Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut, NotFoundException notFoundException)
         {
             //Arrange
-            var notFoundException = fixture.Create<NotFoundException>();
             Mock.Get(dealSelector).Setup(x => x.GetDeal(hubSpotClient)).Throws(notFoundException);
 
             //Act
@@ -111,10 +110,9 @@ namespace Tests.Deals
         }
 
         [Test, CustomAutoData]
-        public async Task GetAsync_returns_null_if_pipeline_retrieving_throws_NotFoundeException([Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut, string guid, IFixture fixture)
+        public async Task GetAsync_returns_null_if_pipeline_retrieving_throws_NotFoundeException([Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut, NotFoundException notFoundException)
         {
             //Arrange
-            var notFoundException = fixture.Create<NotFoundException>();
             Mock.Get(hubSpotClient).Setup(x => x.Pipelines.GetByGuidAsync(It.IsAny<string>())).Throws(notFoundException);
 
             //Act

--- a/tests/Tests.HubSpot/Deals/HubSpotDealConnectorTests.cs
+++ b/tests/Tests.HubSpot/Deals/HubSpotDealConnectorTests.cs
@@ -1,0 +1,125 @@
+﻿using AutoFixture;
+using AutoFixture.Idioms;
+using AutoFixture.NUnit3;
+using HubSpot;
+using HubSpot.Deals;
+using HubSpot.Model.Deals;
+using HubSpot.Model.Pipelines;
+using Kralizek.Extensions.Http;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Tests.Deals
+{
+    [TestFixture]
+    public class HubSpotDealConnectorTests
+    {
+        [Test, CustomAutoData]
+        public void Constructor_is_guarded_against_null_parameters(GuardClauseAssertion guardClauseAssertion)
+        {
+            //Arrange
+
+            //Act
+
+            //Assert
+            guardClauseAssertion.Verify(typeof(HubSpotDealConnector).GetConstructors());
+        }
+
+        [Test, CustomAutoData]
+        public void GetAsync_is_guarded_against_null_selector(HubSpotDealConnector sut)
+        {
+            //Arrange
+
+            //Act
+
+            //Assert
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await sut.GetAsync<HubSpot.Deals.Deal>(null));
+        }
+
+        [Test, CustomAutoData]
+        public async Task GetAsync_invokes_selector_from_parameters_to_retrieve_deal([Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut)
+        {
+            //Arrange
+
+            //Act
+            await sut.GetAsync<HubSpot.Deals.Deal>(dealSelector);
+
+            //Assert
+            Mock.Get(dealSelector).Verify(x => x.GetDeal(hubSpotClient), Times.Once);
+        }
+
+        [Test, CustomAutoData]
+        public async Task GetAsync_invokes_deal_type_manager_to_convert_selector_result([Frozen] IDealTypeManager dealTypeManager, [Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut,HubSpot.Model.Deals.Deal deal)
+        {
+            //Arrange
+            Mock.Get(dealSelector).Setup(x => x.GetDeal(hubSpotClient)).Returns(Task.FromResult(deal));
+
+            //Act
+            await sut.GetAsync<HubSpot.Deals.Deal>(dealSelector);
+
+            //Assert
+            Mock.Get(dealTypeManager).Verify(x => x.ConvertTo<HubSpot.Deals.Deal>(deal), Times.Once);
+        }
+
+        [Test, CustomAutoData]
+        public async Task GetAsync_returns_converted_deal([Frozen] IDealTypeManager dealTypeManager, [Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut, IFixture fixture) 
+        {
+            //Arrange
+            var convertedDeal = fixture.Build<HubSpot.Deals.Deal>().Without(x => x.Pipeline).Create();
+            Mock.Get(dealTypeManager).Setup(x => x.ConvertTo<HubSpot.Deals.Deal>(It.IsAny<HubSpot.Model.Deals.Deal>())).Returns(convertedDeal);
+            Mock.Get(hubSpotClient).Setup(x => x.Pipelines.GetByGuidAsync(It.IsAny<string>())).Returns(Task.FromResult((Pipeline)null));
+
+            //Act
+            var result = await sut.GetAsync<HubSpot.Deals.Deal>(dealSelector);
+
+            //Assert
+            Assert.That(result, Is.EqualTo(convertedDeal));
+        }
+
+        [Test, CustomAutoData]
+        public async Task GetAsync_returns_deal_with_pipeline_retrieved_by_http_client([Frozen] IDealTypeManager dealTypeManager, [Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut, IFixture fixture, Pipeline pipeline)
+        {
+            //Arrange
+            var convertedDeal = fixture.Build<HubSpot.Deals.Deal>().Without(x => x.Pipeline).Create();
+            Mock.Get(dealTypeManager).Setup(x => x.ConvertTo<HubSpot.Deals.Deal>(It.IsAny<HubSpot.Model.Deals.Deal>())).Returns(convertedDeal);
+            Mock.Get(hubSpotClient).Setup(x => x.Pipelines.GetByGuidAsync(It.IsAny<string>())).Returns(Task.FromResult(pipeline));
+
+            //Act
+            var result = await sut.GetAsync<HubSpot.Deals.Deal>(dealSelector);
+
+            //Assert
+            Assert.That(result.Pipeline, Is.EqualTo(pipeline));
+        }
+
+        [Test, CustomAutoData]
+        public async Task GetAsync_returns_null_if_deal_retrieving_throws_NotFoundException([Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut)
+        {
+            //Arrange
+            Mock.Get(dealSelector).Setup(x => x.GetDeal(hubSpotClient)).Throws(new NotFoundException("Not Found", new Exception()));
+
+            //Act
+            var result = await sut.GetAsync<HubSpot.Deals.Deal>(dealSelector);
+
+            //Assert
+            Assert.That(result, Is.Null);
+        }
+
+        [Test, CustomAutoData]
+        public async Task GetAsync_returns_null_if_pipeline_retrieving_throws_NotFoundeException([Frozen] IHubSpotClient hubSpotClient, [Frozen] IDealSelector dealSelector, HubSpotDealConnector sut, string guid)
+        {
+            //Arrange
+            Mock.Get(hubSpotClient).Setup(x => x.Pipelines.GetByGuidAsync(It.IsAny<string>())).Throws(new NotFoundException("Not Found", new Exception()));
+
+            //Act
+            var result = await sut.GetAsync<HubSpot.Deals.Deal>(dealSelector);
+
+            //Assert
+            Assert.That(result, Is.Null);
+        }
+    }
+}


### PR DESCRIPTION
Added http client component (with unit tests) to retrieve pipelines.
Updated deal model to include pipeline.
Retrieving a deal will also retrieve the pipeline associated.